### PR TITLE
fix comment of backslash

### DIFF
--- a/addon/globalPlugins/phoneticPunctuation/phoneticPunctuation.py
+++ b/addon/globalPlugins/phoneticPunctuation/phoneticPunctuation.py
@@ -143,7 +143,7 @@ defaultRules = """
     {
         "builtInWavFile": "punctuation\\Backslash.wav",
         "caseSensitive": true,
-        "comment": "]",
+        "comment": "\",
         "duration": 361,
         "enabled": true,
         "endAdjustment": 0,


### PR DESCRIPTION
The default comment of the rule of "\\" was being "]".
So I fixed the typo.