### PR TITLE
Fix config, outputDevice is now in audio, not speech. Also updated la…

### DIFF
--- a/addon/globalPlugins/phoneticPunctuation/commands.py
+++ b/addon/globalPlugins/phoneticPunctuation/commands.py
@@ -43,7 +43,7 @@ import wx
 
 from .utils import *
 
-ppSynchronousPlayer = nvwave.WavePlayer(channels=2, samplesPerSec=int(tones.SAMPLE_RATE), bitsPerSample=16, outputDevice=config.conf["speech"]["outputDevice"],wantDucking=True)
+ppSynchronousPlayer = nvwave.WavePlayer(channels=2, samplesPerSec=int(tones.SAMPLE_RATE), bitsPerSample=16, outputDevice=config.conf["audio"]["outputDevice"],wantDucking=True)
 
 class PpSynchronousCommand(speech.commands.BaseCallbackCommand):
     def getDuration(self):
@@ -105,7 +105,7 @@ class PpWaveFileCommand(PpSynchronousCommand):
             n = len(unpacked)
         packed = struct.pack(f"<{n}h", *unpacked)
         self.buf = packed
-        self.fileWavePlayer = nvwave.WavePlayer(channels=f.getnchannels(), samplesPerSec=f.getframerate(),bitsPerSample=f.getsampwidth()*8, outputDevice=config.conf["speech"]["outputDevice"],wantDucking=False)
+        self.fileWavePlayer = nvwave.WavePlayer(channels=f.getnchannels(), samplesPerSec=f.getframerate(),bitsPerSample=f.getsampwidth()*8, outputDevice=config.conf["audio"]["outputDevice"],wantDucking=False)
 
     def run(self):
         f = self.f

--- a/buildVars.py
+++ b/buildVars.py
@@ -32,7 +32,7 @@ Please check out documentation for the full list of available speech rules."""),
     # Minimum NVDA version supported (e.g. "2018.3")
     "addon_minimumNVDAVersion": "2019.3.0",
     # Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-    "addon_lastTestedNVDAVersion": "2024.1.0",
+    "addon_lastTestedNVDAVersion": "2025.1",
     # Add-on update channel (default is stable or None)
     "addon_updateChannel": None,
 }


### PR DESCRIPTION
…st tested NVDA to 2025.1. This config fix re-enables sounds for rules instead of just having the role names omitted.